### PR TITLE
Remove unnecessary unlock

### DIFF
--- a/server/runtime.go
+++ b/server/runtime.go
@@ -243,7 +243,6 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 			return nil, fmt.Errorf("failed to delete container %s in sandbox %s: %v", c.Name(), *sbName, err)
 		}
 		if podInfraContainer == c.Name() {
-			sb.containersLock.Unlock()
 			continue
 		}
 		containerDir := filepath.Join(s.runtime.ContainerDir(), c.Name())


### PR DESCRIPTION
Fix for
```
panic: sync: unlock of unlocked mutex

goroutine 69 [running]:
panic(0x8a8f20, 0xc42037c970)
        /usr/lib/golang/src/runtime/panic.go:500 +0x1a1
sync.(*Mutex).Unlock(0xc42036d528)
        /usr/lib/golang/src/sync/mutex.go:111 +0x104
github.com/kubernetes-incubator/ocid/server.(*Server).RemovePodSandbox(0xc42036cd40, 0x7fb63e5262a0, 0xc4203425d0, 0xc42037ef20, 0x0, 0xd, 0xd)
        /root/gosrc/src/github.com/kubernetes-incubator/ocid/server/runtime.go:255 +0x2c3
github.com/kubernetes-incubator/ocid/vendor/github.com/kubernetes/kubernetes/pkg/kubelet/api/v1alpha1/runtime._RuntimeService_RemovePodSandbox_Handler(0x954740, 0xc42036cd40, 0x7fb63e5262a0, 0xc4203425d0, 0xc42024c960, 0x0, 0x0, 0x0, 0x0, 0x0)
        /root/gosrc/src/github.com/kubernetes-incubator/ocid/vendor/github.com/kubernetes/kubernetes/pkg/kubelet/api/v1alpha1/runtime/api.pb.go:2698 +0x27d
github.com/kubernetes-incubator/ocid/vendor/google.golang.org/grpc.(*Server).processUnaryRPC(0xc4202ab540, 0xbec820, 0xc42001e5a0, 0xc4201682d0, 0xc42036b110, 0xc06ac8, 0xc4203424b0, 0x0, 0x0)
        /root/gosrc/src/github.com/kubernetes-incubator/ocid/vendor/google.golang.org/grpc/server.go:608 +0xc50
github.com/kubernetes-incubator/ocid/vendor/google.golang.org/grpc.(*Server).handleStream(0xc4202ab540, 0xbec820, 0xc42001e5a0, 0xc4201682d0, 0xc4203424b0)
        /root/gosrc/src/github.com/kubernetes-incubator/ocid/vendor/google.golang.org/grpc/server.go:766 +0x6b0
github.com/kubernetes-incubator/ocid/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc42037c610, 0xc4202ab540, 0xbec820, 0xc42001e5a0, 0xc4201682d0)
        /root/gosrc/src/github.com/kubernetes-incubator/ocid/vendor/google.golang.org/grpc/server.go:419 +0xab
created by github.com/kubernetes-incubator/ocid/vendor/google.golang.org/grpc.(*Server).serveStreams.func1
        /root/gosrc/src/github.com/kubernetes-incubator/ocid/vendor/google.golang.org/grpc/server.go:420 +0xa3

```

To reproduce the issue, pod create, pod stop, pod remove. 

@runcom PTAL.
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>