### PR TITLE
server/sandbox: fix path to pause rootfs

### DIFF
--- a/server/sandbox.go
+++ b/server/sandbox.go
@@ -75,7 +75,7 @@ func (s *Server) CreatePodSandbox(ctx context.Context, req *pb.CreatePodSandboxR
 	g := generate.New()
 
 	// setup defaults for the pod sandbox
-	g.SetRootPath(filepath.Join(podInfraRootfs, "rootfs"))
+	g.SetRootPath(podInfraRootfs)
 	g.SetRootReadonly(true)
 	g.SetProcessArgs([]string{"/pause"})
 


### PR DESCRIPTION
I flaky tested https://github.com/kubernetes-incubator/ocid/pull/45 (I forgot I already had a rootfs there and it wasn't failing when I merged that PR).
After `rm -rf /var/lib/ocid` however I got an error in ocid when starting the pod sandbox container.
This fixed it, my bad.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>